### PR TITLE
Fixes for python3

### DIFF
--- a/youtube/youtube-dl/Dockerfile
+++ b/youtube/youtube-dl/Dockerfile
@@ -5,16 +5,26 @@
 FROM alpine
 MAINTAINER kev <noreply@easypi.pro>
 
-RUN set -xe \
-    && apk add --no-cache ca-certificates \
-                          ffmpeg \
-                          openssl \
-                          python3 \
-                          aria2 \
-    && pip3 install youtube-dl
+#RUN set -xe \
+#    && apk add --no-cache ca-certificates \
+#                          ffmpeg \
+#                          openssl \
+#                          python3 \
+#                          aria2 
+
+#RUN apk --update add python
+RUN apk add --no-cache python3
+RUN apk add --no-cache curl
+RUN apk add --no-cache ffmpeg
+RUN apk add --no-cache openssl
+RUN apk add --no-cache ca-certificates
+
+ADD https://yt-dl.org/downloads/latest/youtube-dl /usr/local/bin/youtube-dl
+RUN chmod a+rx /usr/local/bin/youtube-dl
+RUN ln -s /usr/bin/python3 /usr/local/bin/python 
 
 # Try to run it so we know it works
-RUN youtube-dl --version
+RUN /usr/local/bin/youtube-dl --version
 
 WORKDIR /data
 


### PR DESCRIPTION
I recently had to re-create a docker image based on this YouTube-dl docker file, and found that it was throwing the following errors:

```
ERROR: unsatisfiable constraints:
  python (missing):
    required by: world[python]
```

Trying to install python in 3.12 of alpine, I got:

```
apk --update add python
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  python (missing):
    required by: world[python]
```

Found this: https://github.com/docker-library/docker/issues/240

So, I just changed this to use python3 and linked python to python3. Note that in this version of the Dockerfile, my intent is to pull the latest version of YouTube-dl instead of the repo version.
